### PR TITLE
Implement 'All On' and 'All Off' buttons

### DIFF
--- a/OVRLighthouseManager/Strings/en-us/Resources.resw
+++ b/OVRLighthouseManager/Strings/en-us/Resources.resw
@@ -246,4 +246,10 @@
   <data name="Shell_Main_PowerDownMode_Standby.ToolTipService.ToolTip" xml:space="preserve">
     <value>Power off only lasers (Only for Base Station 2.0).</value>
   </data>
+  <data name="Shell_Main_PowerAll_AllOff.Text" xml:space="preserve">
+    <value>All Off</value>
+  </data>
+  <data name="Shell_Main_PowerAll_AllOn.Text" xml:space="preserve">
+    <value>All On</value>
+  </data>
 </root>

--- a/OVRLighthouseManager/Strings/ja-jp/Resources.resw
+++ b/OVRLighthouseManager/Strings/ja-jp/Resources.resw
@@ -246,4 +246,10 @@
   <data name="Shell_Main_PowerDownMode_Standby.ToolTipService.ToolTip" xml:space="preserve">
     <value>ベースステーションのレーザーのみ電源を切ります。(ベースステーション2.0のみ)</value>
   </data>
+  <data name="Shell_Main_PowerAll_AllOff.Text" xml:space="preserve">
+    <value />
+  </data>
+  <data name="Shell_Main_PowerAll_AllOn.Text" xml:space="preserve">
+    <value />
+  </data>
 </root>

--- a/OVRLighthouseManager/Views/MainPage.xaml
+++ b/OVRLighthouseManager/Views/MainPage.xaml
@@ -100,6 +100,48 @@
                         </StackPanel>
                     </Button.Content>
                 </Button>
+                <Button Grid.Column="0"
+                        Grid.Row="1"
+                        x:Name="PowerOnAll"
+                        Command="{x:Bind ViewModel.PowerAllCommand}"
+                        CommandParameter="powerOn"
+                        >
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <ProgressRing
+                                IsActive="{x:Bind ViewModel.IsDoingPowerAll, Mode=OneWay}"
+                                Height="8"
+                                Width="8"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Center"
+                                Visibility="{x:Bind ViewModel.IsDoingPowerAll, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                Margin="{StaticResource XSmallRightMargin}"
+                                />
+                            <TextBlock x:Uid="Shell_Main_PowerAll_AllOn" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
+                <Button Grid.Column="0"
+                        Grid.Row="1"
+                        x:Name="PowerOffAll"
+                        Command="{x:Bind ViewModel.PowerAllCommand}"
+                        CommandParameter="powerDown"
+                        >
+                    <Button.Content>
+                        <StackPanel Orientation="Horizontal">
+                            <ProgressRing
+                                IsActive="{x:Bind ViewModel.IsDoingPowerAll, Mode=OneWay}"
+                                Height="8"
+                                Width="8"
+                                VerticalAlignment="Center"
+                                HorizontalAlignment="Center"
+                                Visibility="{x:Bind ViewModel.IsDoingPowerAll, Mode=OneWay, Converter={StaticResource BooleanToVisibilityConverter}}"
+                                Margin="{StaticResource XSmallRightMargin}"
+                                />
+                            <TextBlock x:Uid="Shell_Main_PowerAll_AllOff" />
+                        </StackPanel>
+                    </Button.Content>
+                </Button>
             </StackPanel>
             <TextBlock x:Uid="Shell_Main_BaseStationsDescription"
                        TextWrapping="WrapWholeWords"


### PR DESCRIPTION
Sometimes it's convenient to turn all (managed) base stations on or off with a single button press. E.g. occasionally my power flickers and causes all base stations to turn on, and I want to turn them all back off easily.

I added "All On" and "All Off" buttons. When the "All On" button is clicked, it sends the power-on command to all managed base stations. When the "All Off" button is clicked, it sends the selected power-down mode command (either standby or sleep) to all managed base stations. After clicking a button, both buttons are disabled with loading spinners until the commands all complete.

I tested it on my own 2.0 base stations, and my friend's 1.0 base stations. I tested that the new buttons don't affect unmanaged base stations.

There are new strings in the text resources, `Shell_Main_PowerAll_AllOff` and `Shell_Main_PowerAll_AllOn`, but I didn't add anything for the Japanese translation since I don't know Japanese. Feel free to add that in, or tell me what it should say and I can add it.

Last thing -- I'm not very familiar with WPF (or the MVVM paradigm of programming in general), so apologizes if I did anything silly. I tried to match my style of coding to how your code is. Let me know if you have issues with my code and I can try to fix it!