### PR TITLE
Add 'Identify' button to Lighthouse dropdown menu

### DIFF
--- a/OVRLighthouseManager/Contracts/Services/ILighthouseGattService.cs
+++ b/OVRLighthouseManager/Contracts/Services/ILighthouseGattService.cs
@@ -13,4 +13,6 @@ internal interface ILighthouseGattService
     public Task SleepAsync(Lighthouse lighthouse);
 
     public Task StandbyAsync(Lighthouse lighthouse);
+
+    public Task IdentifyAsync(Lighthouse lighthouse);
 }

--- a/OVRLighthouseManager/Services/LighthouseGattService.cs
+++ b/OVRLighthouseManager/Services/LighthouseGattService.cs
@@ -16,6 +16,7 @@ class LighthouseGattService : ILighthouseGattService
 
     private static readonly Guid V2ControlService = new("00001523-1212-efde-1523-785feabcd124");
     private static readonly Guid V2PowerCharacteristic = new("00001525-1212-efde-1523-785feabcd124");
+    private static readonly Guid V2IdentifyCharacteristic = new("00008421-1212-efde-1523-785feabcd124");
 
     private static readonly ILogger _log = LogHelper.ForContext<LighthouseGattService>();
 
@@ -57,6 +58,15 @@ class LighthouseGattService : ILighthouseGattService
             throw new LighthouseGattException("Standby is not supported on V1 lighthouses");
         }
         await WriteV2PowerCharacteristic(lighthouse, 0x02);
+    }
+
+    public async Task IdentifyAsync(Lighthouse lighthouse)
+    {
+        if (lighthouse.Version == LighthouseVersion.V1)
+        {
+            throw new LighthouseGattException("Identify is not supported for V1 lighthouses");
+        }
+        await WritePowerCharacteristicAsync(lighthouse, V2ControlService, V2IdentifyCharacteristic, new byte[] { 0x01 });
     }
 
     private async Task ControlV1Async(Lighthouse lighthouse, bool powerOn)

--- a/OVRLighthouseManager/Strings/en-us/Resources.resw
+++ b/OVRLighthouseManager/Strings/en-us/Resources.resw
@@ -162,6 +162,9 @@
   <data name="Menu_Standby.Text" xml:space="preserve">
     <value>Standby</value>
   </data>
+  <data name="Menu_Identify.Text" xml:space="preserve">
+    <value>Identify</value>
+  </data>
   <data name="Shell_Main_BaseStationsLabel.Text" xml:space="preserve">
     <value>Base Stations</value>
   </data>
@@ -188,6 +191,9 @@
   </data>
   <data name="Notification_Standby" xml:space="preserve">
     <value>{0} has been put to standby.</value>
+  </data>
+  <data name="Notification_Identify" xml:space="preserve">
+    <value>{0} is identifying itself.</value>
   </data>
   <data name="Shell_Main_PowerManagementDescription.Text" xml:space="preserve">
     <value>When you start SteamVR, they wake up from standby, and when you exit SteamVR, they go to standby. Neither HTC VIVE nor Valve Index required.</value>

--- a/OVRLighthouseManager/Strings/ja-jp/Resources.resw
+++ b/OVRLighthouseManager/Strings/ja-jp/Resources.resw
@@ -162,6 +162,9 @@
   <data name="Menu_Standby.Text" xml:space="preserve">
     <value>スタンバイ</value>
   </data>
+  <data name="Menu_Identify.Text" xml:space="preserve">
+    <value />
+  </data>
   <data name="Shell_Main_BaseStationsLabel.Text" xml:space="preserve">
     <value>ベースステーション</value>
   </data>
@@ -188,6 +191,9 @@
   </data>
   <data name="Notification_Standby" xml:space="preserve">
     <value>{0}をスタンバイ状態にしました。</value>
+  </data>
+  <data name="Notification_Identify" xml:space="preserve">
+    <value>{0}</value>
   </data>
   <data name="Shell_Main_PowerManagementDescription.Text" xml:space="preserve">
     <value>SteamVRを起動するとスタンバイ状態から復帰し、SteamVRを終了するとスタンバイ状態にします。HTC VIVEおよびValve Indexは必要ありません。</value>

--- a/OVRLighthouseManager/Views/LighthouseControl.xaml
+++ b/OVRLighthouseManager/Views/LighthouseControl.xaml
@@ -13,6 +13,7 @@
         <helpers:PowerOnCommand x:Key="powerOnCommand" />
         <helpers:SleepCommand x:Key="sleepCommand" />
         <helpers:StandbyCommand x:Key="standbyCommand" />
+        <helpers:IdentifyCommand x:Key="identifyCommand" />
         <helpers:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
     </UserControl.Resources>
 
@@ -108,6 +109,12 @@
                     <MenuFlyoutItem
                         x:Uid="Menu_Standby"
                         Command="{StaticResource standbyCommand}"
+                        CommandParameter="{x:Bind LighthouseObject, Mode=OneWay}"
+                        />
+                    <MenuFlyoutSeparator />
+                    <MenuFlyoutItem
+                        x:Uid="Menu_Identify"
+                        Command="{StaticResource identifyCommand}"
                         CommandParameter="{x:Bind LighthouseObject, Mode=OneWay}"
                         />
                     <MenuFlyoutSeparator />


### PR DESCRIPTION
One more little feature 😄 This one isn't really that important, feel free to reject the PR if you don't think it's necessary for this program. I'm just hooking up the Identify feature of the base stations to a button in the menu.

---

I'm reusing `WritePowerCharacteristicAsync` for this, which isn't quite accurate since Identify isn't a power characteristic. And the log messages issued by `WritePowerCharacteristicAsync` say "power characteristic" too. If you wanted to make it more accurate, you could just remove the word "Power" from that function.

---

I only supported V2 base stations. I think V1 base stations also have an Identify feature, but I couldn't find documentation for how to invoke it, and I don't have any to test with. So I just marked it as unsupported for V1.

One additional thing I could do is to set the Visibility to hidden for the Identify button on V1 base stations (that could also be done for the Standby button!). But when I tried to Bind visibility to the version of the lighthouse like this:
```diff
diff --git a/OVRLighthouseManager/Models/Lighthouse.cs b/OVRLighthouseManager/Models/Lighthouse.cs
index ff29bc5..9965482 100644
--- a/OVRLighthouseManager/Models/Lighthouse.cs
+++ b/OVRLighthouseManager/Models/Lighthouse.cs
@@ -45,4 +45,7 @@ public class Lighthouse
             return LighthouseVersion.Unknown;
         }
     }
+
+    [JsonIgnore]
+    public bool SupportsIdentify => Version == LighthouseVersion.V2;
 }
diff --git a/OVRLighthouseManager/Views/LighthouseControl.xaml b/OVRLighthouseManager/Views/LighthouseControl.xaml
index 57bfb63..b392d58 100644
--- a/OVRLighthouseManager/Views/LighthouseControl.xaml
+++ b/OVRLighthouseManager/Views/LighthouseControl.xaml
@@ -116,8 +116,9 @@
                         x:Uid="Menu_Identify"
                         Command="{StaticResource identifyCommand}"
                         CommandParameter="{x:Bind LighthouseObject, Mode=OneWay}"
+                        Visibility="{x:Bind LighthouseObject.Lighthouse.SupportsIdentify}"
                         />
-                    <MenuFlyoutSeparator />
+                    <MenuFlyoutSeparator Visibility="{x:Bind LighthouseObject.Lighthouse.SupportsIdentify}"/>
                     <MenuFlyoutItem
                         x:Uid="Menu_EditId"
                         Command="{x:Bind LighthouseObject.EditIdCommand, Mode=OneWay}"
```
it didn't have any effect. I put a break point on the property and it seems it was never being read. I also tried making a `SupportsIdentify` property in the `LighthouseControl` code-behind and Bind to that instead, and that time the code gets executed, but it gets executed before `LighthouseObject` is set, and never gets re-executed once `LighthouseObject` is set, so the visibility binding gets the wrong value. I'm sure there's a way to get it to refresh, but I didn't investigate further, since I'm not sure if you even want this feature in the program at all!